### PR TITLE
Accessibility settings: reduce motion + color filters

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -461,6 +461,58 @@ textarea {
   .urgent-game-banner__marquee-text--scrolling {
     animation: none;
   }
+
+  .avatar-preview-spinner-ring {
+    animation: none;
+  }
+
+  .login-box h1,
+  .pixel-place-title {
+    animation: none !important;
+  }
+
+  .gender-other.selected {
+    animation: none;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+html.reduce-motion .urgent-game-banner__inner {
+  animation: none;
+}
+
+html.reduce-motion .urgent-game-banner__marquee-text--scrolling {
+  animation: none;
+}
+
+html.reduce-motion .avatar-preview-spinner-ring {
+  animation: none;
+}
+
+html.reduce-motion .login-box h1,
+html.reduce-motion .pixel-place-title {
+  animation: none !important;
+}
+
+html.reduce-motion .gender-other.selected {
+  animation: none;
+}
+
+html.reduce-motion *,
+html.reduce-motion *::before,
+html.reduce-motion *::after {
+  animation-duration: 0.01ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.01ms !important;
+  scroll-behavior: auto !important;
 }
 
 /* Push scrollable app below fixed urgent bar */
@@ -2038,7 +2090,7 @@ footer a:hover {
 }
 
 /* ========== STYLE THEMES ========== */
-[data-style="normal"] { /* default, no overrides */ }
+
 
 [data-style="modern"] {
   --panel-radius: 12px;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { UserProvider } from "@/contexts/UserContext";
 import { StyleProvider } from "@/components/StyleProvider";
 import { SecretThemeProvider } from "@/contexts/SecretThemeContext";
 import { SoundProvider } from "@/contexts/SoundContext";
+import { AccessibilityProvider } from "@/contexts/AccessibilityContext";
 import SoundEffects from "@/components/SoundEffects";
 import { getSchemaOrgJsonLd } from "@/lib/schemaOrg";
 
@@ -40,16 +41,18 @@ export default function RootLayout({
       </head>
       <body>
         <StyleProvider>
-          <SecretThemeProvider>
-            <SoundProvider>
-              <MobileBetaProvider>
-                <UserProvider>
-                  <SoundEffects />
-                  {children}
-                </UserProvider>
-              </MobileBetaProvider>
-            </SoundProvider>
-          </SecretThemeProvider>
+          <AccessibilityProvider>
+            <SecretThemeProvider>
+              <SoundProvider>
+                <MobileBetaProvider>
+                  <UserProvider>
+                    <SoundEffects />
+                    {children}
+                  </UserProvider>
+                </MobileBetaProvider>
+              </SoundProvider>
+            </SecretThemeProvider>
+          </AccessibilityProvider>
         </StyleProvider>
       </body>
     </html>

--- a/components/FloatingParticles.tsx
+++ b/components/FloatingParticles.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
+import { useReducedMotionEffective } from '@/contexts/AccessibilityContext';
 
 export default function FloatingParticles() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const reducedMotion = useReducedMotionEffective();
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -12,7 +14,7 @@ export default function FloatingParticles() {
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
-    let animationId: number;
+    let animationId = 0;
     let particles: { x: number; y: number; vx: number; vy: number; size: number; opacity: number }[] = [];
 
     const resize = () => {
@@ -55,16 +57,23 @@ export default function FloatingParticles() {
 
     resize();
     window.addEventListener('resize', resize);
-    animate();
+
+    if (!reducedMotion) {
+      animate();
+    } else {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+    }
+
     return () => {
       window.removeEventListener('resize', resize);
       cancelAnimationFrame(animationId);
     };
-  }, []);
+  }, [reducedMotion]);
 
   return (
     <canvas
       ref={canvasRef}
+      className="floating-particles-canvas"
       style={{
         position: 'fixed',
         top: 0,
@@ -73,7 +82,7 @@ export default function FloatingParticles() {
         height: '100%',
         pointerEvents: 'none',
         zIndex: 0,
-        opacity: 0.6,
+        opacity: reducedMotion ? 0 : 0.6,
       }}
       aria-hidden
     />

--- a/components/Tabs/SettingsTab.tsx
+++ b/components/Tabs/SettingsTab.tsx
@@ -11,6 +11,7 @@ import { useStyle } from '@/components/StyleProvider';
 import { useSound } from '@/contexts/SoundContext';
 import { useSecretTheme } from '@/contexts/SecretThemeContext';
 import { useMobileBeta } from '@/contexts/MobileBetaContext';
+import { useAccessibility, type ColorBlindMode } from '@/contexts/AccessibilityContext';
 import { STYLE_OPTIONS } from '@/lib/styleTheme';
 
 interface SettingsTabProps {
@@ -25,6 +26,14 @@ export default function SettingsTab({ user, editMode, onToggleEditMode }: Settin
   const { soundsEnabled, setSoundsEnabled } = useSound();
   const { secretTheme, unlockSecretTheme, clearSecretTheme } = useSecretTheme();
   const { isMobileBeta, forceDesktop, setForceDesktop } = useMobileBeta();
+  const {
+    reduceMotion,
+    setReduceMotion,
+    invertColors,
+    setInvertColors,
+    colorBlindMode,
+    setColorBlindMode,
+  } = useAccessibility();
   const [skins, setSkins] = useState<Skin[]>([]);
   const [tabContent, setTabContent] = useState<TabContent | null>(null);
   const [secretPasswordModal, setSecretPasswordModal] = useState(false);
@@ -108,6 +117,69 @@ export default function SettingsTab({ user, editMode, onToggleEditMode }: Settin
           />
           <span>Enable sound effects</span>
         </label>
+      </div>
+
+      <div className="ai-box">
+        <div className="ai-label">Accessibility</div>
+        <div className="ai-output" style={{ marginBottom: '12px' }}>
+          Adjust motion and colors for comfort. Device &quot;reduce motion&quot; is always honored; you can
+          also turn on extra options here. Color filters are approximate and apply to the whole page.
+        </div>
+        <label style={{ display: 'flex', alignItems: 'center', gap: '10px', cursor: 'pointer' }}>
+          <input
+            type="checkbox"
+            checked={reduceMotion}
+            onChange={(e) => setReduceMotion(e.target.checked)}
+            style={{ width: '18px', height: '18px' }}
+          />
+          <span>Reduce motion (fewer animations and transitions)</span>
+        </label>
+        <label
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '10px',
+            cursor: 'pointer',
+            marginTop: '10px',
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={invertColors}
+            onChange={(e) => setInvertColors(e.target.checked)}
+            style={{ width: '18px', height: '18px' }}
+          />
+          <span>Invert colors (light/dark flip for the whole site)</span>
+        </label>
+        <div style={{ marginTop: '14px' }}>
+          <label htmlFor="pixelplace-colorblind" style={{ display: 'block', marginBottom: '6px' }}>
+            Color vision filter
+          </label>
+          <select
+            id="pixelplace-colorblind"
+            value={colorBlindMode}
+            onChange={(e) => setColorBlindMode(e.target.value as ColorBlindMode)}
+            style={{
+              width: '100%',
+              maxWidth: '360px',
+              padding: '10px 12px',
+              borderRadius: '8px',
+              border: '1px solid var(--border)',
+              background: 'var(--panel-soft)',
+              color: 'var(--text-main)',
+              fontSize: '14px',
+            }}
+          >
+            <option value="none">None</option>
+            <option value="protanopia">Red–green (protanopia-style)</option>
+            <option value="deuteranopia">Red–green (deuteranopia-style)</option>
+            <option value="tritanopia">Blue–yellow (tritanopia-style)</option>
+          </select>
+          <p style={{ margin: '8px 0 0', fontSize: 13, color: 'var(--text-dim)' }}>
+            These use common color matrices for preview and experimentation; they are not a medical
+            calibration.
+          </p>
+        </div>
       </div>
 
       <div className="ai-box">

--- a/components/UrgentGameBanner.tsx
+++ b/components/UrgentGameBanner.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { resolveClientApiUrl } from '@/lib/apiBaseUrl';
 import { getStatusPageUrl } from '@/lib/statusPageUrl';
+import { readReducedMotionPreferred } from '@/lib/a11yReducedMotion';
 
 const STORAGE_KEY = 'pixelplace_urgent_autodismiss_v1';
 
@@ -90,6 +91,7 @@ export default function UrgentGameBanner() {
     if (!payload) return;
 
     const { dismissKey } = payload;
+    const textEl = textRef.current;
     const timeouts: number[] = [];
     let raf1 = 0;
     let raf2 = 0;
@@ -126,7 +128,7 @@ export default function UrgentGameBanner() {
       const trackW = track.clientWidth;
       const scrollW = text.scrollWidth;
       const overflow = scrollW - trackW;
-      const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      const reduceMotion = readReducedMotionPreferred();
 
       if (overflow <= 4) {
         timeouts.push(window.setTimeout(finish, 10_000));
@@ -161,8 +163,7 @@ export default function UrgentGameBanner() {
       window.cancelAnimationFrame(raf1);
       window.cancelAnimationFrame(raf2);
       timeouts.forEach((t) => window.clearTimeout(t));
-      const text = textRef.current;
-      if (text) resetTextStyles(text);
+      if (textEl) resetTextStyles(textEl);
     };
   }, [payload]);
 

--- a/contexts/AccessibilityContext.tsx
+++ b/contexts/AccessibilityContext.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+export type ColorBlindMode = 'none' | 'protanopia' | 'deuteranopia' | 'tritanopia';
+
+type AccessibilityContextType = {
+  reduceMotion: boolean;
+  setReduceMotion: (v: boolean) => void;
+  invertColors: boolean;
+  setInvertColors: (v: boolean) => void;
+  colorBlindMode: ColorBlindMode;
+  setColorBlindMode: (v: ColorBlindMode) => void;
+};
+
+const AccessibilityContext = createContext<AccessibilityContextType | undefined>(undefined);
+
+const KEY_REDUCE = 'pixelplace_a11y_reduce_motion';
+const KEY_INVERT = 'pixelplace_a11y_invert';
+const KEY_CVD = 'pixelplace_a11y_colorblind';
+
+function parseColorBlind(raw: string | null): ColorBlindMode {
+  if (raw === 'protanopia' || raw === 'deuteranopia' || raw === 'tritanopia') return raw;
+  return 'none';
+}
+
+function buildHtmlFilter(colorBlindMode: ColorBlindMode, invertColors: boolean): string {
+  const parts: string[] = [];
+  if (colorBlindMode === 'protanopia') parts.push('url(#pixelplace-cvd-protanopia)');
+  if (colorBlindMode === 'deuteranopia') parts.push('url(#pixelplace-cvd-deuteranopia)');
+  if (colorBlindMode === 'tritanopia') parts.push('url(#pixelplace-cvd-tritanopia)');
+  if (invertColors) parts.push('invert(1) hue-rotate(180deg)');
+  return parts.join(' ');
+}
+
+export function AccessibilityProvider({ children }: { children: React.ReactNode }) {
+  const [reduceMotion, setReduceMotionState] = useState(false);
+  const [invertColors, setInvertColorsState] = useState(false);
+  const [colorBlindMode, setColorBlindModeState] = useState<ColorBlindMode>('none');
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      setReduceMotionState(localStorage.getItem(KEY_REDUCE) === '1');
+      setInvertColorsState(localStorage.getItem(KEY_INVERT) === '1');
+      setColorBlindModeState(parseColorBlind(localStorage.getItem(KEY_CVD)));
+    } catch {
+      /* ignore */
+    }
+    setHydrated(true);
+  }, []);
+
+  const setReduceMotion = useCallback((v: boolean) => {
+    setReduceMotionState(v);
+    try {
+      localStorage.setItem(KEY_REDUCE, v ? '1' : '0');
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  const setInvertColors = useCallback((v: boolean) => {
+    setInvertColorsState(v);
+    try {
+      localStorage.setItem(KEY_INVERT, v ? '1' : '0');
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  const setColorBlindMode = useCallback((v: ColorBlindMode) => {
+    setColorBlindModeState(v);
+    try {
+      localStorage.setItem(KEY_CVD, v);
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated || typeof document === 'undefined') return;
+    document.documentElement.classList.toggle('reduce-motion', reduceMotion);
+  }, [hydrated, reduceMotion]);
+
+  useEffect(() => {
+    if (!hydrated || typeof document === 'undefined') return;
+    const f = buildHtmlFilter(colorBlindMode, invertColors);
+    if (f) document.documentElement.style.filter = f;
+    else document.documentElement.style.removeProperty('filter');
+  }, [hydrated, colorBlindMode, invertColors]);
+
+  const value = useMemo(
+    () => ({
+      reduceMotion,
+      setReduceMotion,
+      invertColors,
+      setInvertColors,
+      colorBlindMode,
+      setColorBlindMode,
+    }),
+    [
+      reduceMotion,
+      setReduceMotion,
+      invertColors,
+      setInvertColors,
+      colorBlindMode,
+      setColorBlindMode,
+    ],
+  );
+
+  return (
+    <AccessibilityContext.Provider value={value}>
+      <svg
+        aria-hidden
+        focusable="false"
+        style={{ position: 'absolute', width: 0, height: 0, overflow: 'hidden' }}
+      >
+        <defs>
+          <filter id="pixelplace-cvd-protanopia" colorInterpolationFilters="sRGB">
+            <feColorMatrix
+              type="matrix"
+              values="0.152286 1.052583 -0.204868 0 0  0.114503 0.786281 0.099216 0 0  -0.003882 -0.048116 1.051998 0 0  0 0 0 1 0"
+            />
+          </filter>
+          <filter id="pixelplace-cvd-deuteranopia" colorInterpolationFilters="sRGB">
+            <feColorMatrix
+              type="matrix"
+              values="0.367322 0.860646 -0.227968 0 0  0.280085 0.672501 0.047413 0 0  -0.01182 0.04294 0.968881 0 0  0 0 0 1 0"
+            />
+          </filter>
+          <filter id="pixelplace-cvd-tritanopia" colorInterpolationFilters="sRGB">
+            <feColorMatrix
+              type="matrix"
+              values="1.255528 -0.076749 -0.178779 0 0  -0.078411 0.930809 -0.147602 0 0  0.004733 0.691367 0.3039 0 0  0 0 0 1 0"
+            />
+          </filter>
+        </defs>
+      </svg>
+      {children}
+    </AccessibilityContext.Provider>
+  );
+}
+
+export function useAccessibility() {
+  const ctx = useContext(AccessibilityContext);
+  if (!ctx) {
+    return {
+      reduceMotion: false,
+      setReduceMotion: () => {},
+      invertColors: false,
+      setInvertColors: () => {},
+      colorBlindMode: 'none' as ColorBlindMode,
+      setColorBlindMode: () => {},
+    };
+  }
+  return ctx;
+}
+
+/** OS “reduce motion” or in-app toggle (for canvas / JS-driven motion). */
+export function useReducedMotionEffective(): boolean {
+  const { reduceMotion: userRm } = useAccessibility();
+  const [osRm, setOsRm] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setOsRm(mq.matches);
+    const onChange = () => setOsRm(mq.matches);
+    mq.addEventListener('change', onChange);
+    return () => mq.removeEventListener('change', onChange);
+  }, []);
+
+  return userRm || osRm;
+}

--- a/lib/a11yReducedMotion.ts
+++ b/lib/a11yReducedMotion.ts
@@ -1,0 +1,8 @@
+/** CSS handles most motion; use this for JS-driven animation (e.g. marquee measure). */
+export function readReducedMotionPreferred(): boolean {
+  if (typeof window === 'undefined') return false;
+  return (
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches ||
+    document.documentElement.classList.contains('reduce-motion')
+  );
+}


### PR DESCRIPTION
## Summary
- Add an Accessibility section in Settings for reduced motion, invert colors, and color-vision filters.
- Wire reduced-motion into the urgent banner behavior and JS-driven particle background.

## Test plan
- Open Settings and toggle Reduce motion, Invert colors, and Color vision filter.
- Verify toggles persist via reload.
- Ensure urgent banner scrolling respects reduced motion.
- Confirm particle background stops animating when reduced motion is enabled (and respects OS reduce motion too).